### PR TITLE
cleanup recording links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,7 +63,7 @@ The recordings of major part of the presentation is available via *Kaltura* and 
 | Section | Content | Video |
 |---------|---------|-------|
 | Outline | Recommended | [8 min](https://kuleuven.mediaspace.kaltura.com/media/HPCIntro-01-Outline/1_q5ul7rya) |
-| VSC | Recommended | [10 min](https://kuleuven.mediaspace.kaltura.com/media/HPCintro-02-VSCintro/1_y7di10vy) |
+| VSC | Recommended | [8 min](https://kuleuven.mediaspace.kaltura.com/media/HPCintro-02-VSCintro/1_y7di10vy) |
 | Tier-2 clusters | Recommended | [13 min](https://kuleuven.mediaspace.kaltura.com/media/HPCIntro-03-Clusters/1_vhiua0ij) |
 | Genius Cluster | Recommended | [3 min](https://kuleuven.mediaspace.kaltura.com/media/HPCIntro-04-Genius/1_p1ylayhz) |
 | Storage | Recommended | [21 min](https://kuleuven.mediaspace.kaltura.com/media/HPCIntro-05-Storage/1_z34wnczy) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,7 +77,7 @@ The recordings of major part of the presentation is available via *Kaltura* and 
 | Start to compute - Demo | Optional |  |
 | GPU partition | Optional |  |
 | BigMem, AMD and debugging queues | Optional |  |
-| Compute credits | Recommended |  |
+| Compute credits | Recommended | [12 min](https://kuleuven.mediaspace.kaltura.com/media/HPCintro-14-credits/1_4c4u01i8) |
 | Worker framework | Optional | [18 min](https://kuleuven.mediaspace.kaltura.com/media/HPCIntro-17-worker/1_pz537i1i) |
 | Epilogue | Recommended | [3 min](https://kuleuven.mediaspace.kaltura.com/media/HPCIntro-18-Epilogue/1_fy8dmbg3) |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,11 +73,11 @@ The recordings of major part of the presentation is available via *Kaltura* and 
 | NX | Optional | [12 min](https://kuleuven.mediaspace.kaltura.com/media/HPCIntro-08-NX/1_o47ne0pm) |
 | File transfer | Optional | [6 min](https://kuleuven.mediaspace.kaltura.com/media/HPCIntro-09-FileTransfer/1_cf3zseab) |
 | Software | Recommended | [13 min](https://kuleuven.mediaspace.kaltura.com/media/HPCIntro-10-Software/1_ql6wq3rp) |
-| Start to compute | Recommended | [36 min](https://kuleuven.mediaspace.kaltura.com/media/HPCIntro-11-SubmitJobs/1_i9s1j78a) |
-| Start to compute - Demo | Optional | [15 min](https://kuleuven.mediaspace.kaltura.com/media/HPCInfo-11-SubmitJobs-demo/1_bmkbvvue) |
-| GPU partition | Optional | [11 min](https://kuleuven.mediaspace.kaltura.com/media/HPCIntro-12-GPUs/1_f38ws9p8) |
-| BigMem, AMD and debugging queues | Optional | [16 min](https://kuleuven.mediaspace.kaltura.com/media/HPCInfo-13-BigMem-AMD-debugging/1_rqjaqvrb) |
-| Compute credits | Recommended | [15 min](https://kuleuven.mediaspace.kaltura.com/media/HPCintro-14-credits/1_4c4u01i8) |
+| Start to compute | Recommended |  |
+| Start to compute - Demo | Optional |  |
+| GPU partition | Optional |  |
+| BigMem, AMD and debugging queues | Optional |  |
+| Compute credits | Recommended |  |
 | Worker framework | Optional | [18 min](https://kuleuven.mediaspace.kaltura.com/media/HPCIntro-17-worker/1_pz537i1i) |
 | Epilogue | Recommended | [3 min](https://kuleuven.mediaspace.kaltura.com/media/HPCIntro-18-Epilogue/1_fy8dmbg3) |
 


### PR DESCRIPTION
Some of the PBS-related recordings are very obsolete, and the link to them are removed (while still keeping the topic in the table for future reference). There are also other recordings which are still kept, and they are partly useful. E.g. storage, worker, modules, etc. We have to revise these, too, but for now they can still stay, because they can still convey the main message (when taken with a grain of salt).